### PR TITLE
Let last will take arbitrary bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ mio = {git = "https://github.com/carllerche/mio.git"}
 rand = "0.3"
 time = "0.1"
 threadpool = "1.3"
-mqtt-protocol = "0.3"
+mqtt-protocol = "0.3.1"
 openssl = { version = "0.8", features = ["tlsv1_2"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ mio = {git = "https://github.com/carllerche/mio.git"}
 rand = "0.3"
 time = "0.1"
 threadpool = "1.3"
-mqtt-protocol = "0.1"
+mqtt-protocol = "0.3"
 openssl = { version = "0.8", features = ["tlsv1_2"] }
 
 [dev-dependencies]

--- a/src/clientoptions.rs
+++ b/src/clientoptions.rs
@@ -11,7 +11,7 @@ pub struct MqttOptions {
     pub username: Option<String>,
     pub password: Option<String>,
     pub reconnect: Option<u16>,
-    pub will: Option<(String, String)>,
+    pub will: Option<(String, Vec<u8>)>,
     pub will_qos: QualityOfService,
     pub will_retain: bool,
     pub pub_q_len: u16,
@@ -154,8 +154,8 @@ impl MqttOptions {
 
     /// Set will for the client so that broker can send `will_message`
     /// on `will_topic` when this client ungracefully dies.
-    pub fn set_will(mut self, will_topic: &str, will_message: &str) -> Self {
-        self.will = Some((will_topic.to_string(), will_message.to_string()));
+    pub fn set_will(mut self, will_topic: &str, will_message: &[u8]) -> Self {
+        self.will = Some((will_topic.to_string(), will_message.to_vec()));
         self
     }
 

--- a/src/genpack.rs
+++ b/src/genpack.rs
@@ -7,7 +7,7 @@ use error::Result;
 pub fn generate_connect_packet(client_id: Option<String>,
                                clean_session: bool,
                                keep_alive: Option<u16>,
-                               will: Option<(String, String)>,
+                               will: Option<(String, Vec<u8>)>,
                                will_qos: QualityOfService,
                                will_retain: bool,
                                username: Option<String>,
@@ -22,7 +22,7 @@ pub fn generate_connect_packet(client_id: Option<String>,
         connect_packet.set_keep_alive(keep_alive);
     }
 
-    // Converting (String, String) -> (TopicName, String)
+    // Converting (String, Vec<u8>) -> (TopicName, Vec<u8>)
     let will = match will {
         Some(will) => Some((try!(TopicName::new(will.0)), will.1)),
         None => None,

--- a/tests/testsuite.rs
+++ b/tests/testsuite.rs
@@ -1,4 +1,4 @@
-#![allow(unused_variables)] 
+#![allow(unused_variables)]
 extern crate rumqtt;
 
 use rumqtt::{MqttOptions, MqttClient, QoS};
@@ -23,7 +23,7 @@ fn inital_tcp_connect_failure(){
                                     .set_reconnect(5)
                                     .broker("localhost:9999");
 
-    // Connects to a broker and returns a `request` 
+    // Connects to a broker and returns a `request`
     let request = MqttClient::new(client_options)
                                 .start().expect("Couldn't start");
 }
@@ -49,7 +49,7 @@ fn inital_mqtt_connect_failure() {
                                     .broker("test.mosquitto.org:8883");
 
 
-    // Connects to a broker and returns a `request` 
+    // Connects to a broker and returns a `request`
     let request = MqttClient::new(client_options)
                                 .start().expect("Couldn't start");
 }
@@ -66,7 +66,7 @@ fn basic_publishes_and_subscribes() {
     let final_count = count.clone();
     let count = count.clone();
 
-    // Connects to a broker and returns a `request` 
+    // Connects to a broker and returns a `request`
     let request = MqttClient::new(client_options).
     message_callback(move |message| {
         count.fetch_add(1, Ordering::SeqCst);
@@ -75,8 +75,8 @@ fn basic_publishes_and_subscribes() {
 
     let topics = vec![("test/basic", QoS::Level0)];
 
-    request.subscribe(topics).expect("Subcription failure");  
-    
+    request.subscribe(topics).expect("Subcription failure");
+
     let payload = format!("hello rust");
     request.publish("test/basic",  QoS::Level0, payload.clone().into_bytes()).unwrap();
     request.publish("test/basic",  QoS::Level1, payload.clone().into_bytes()).unwrap();
@@ -100,7 +100,7 @@ fn simple_reconnection() {
     let final_count = count.clone();
     let count = count.clone();
 
-    // Connects to a broker and returns a `request` 
+    // Connects to a broker and returns a `request`
     let request = MqttClient::new(client_options).
     message_callback(move |message| {
         count.fetch_add(1, Ordering::SeqCst);
@@ -108,7 +108,7 @@ fn simple_reconnection() {
     }).start().expect("Coudn't start");
 
     // Register message callback and subscribe
-    let topics = vec![("test/reconnect", QoS::Level2)];  
+    let topics = vec![("test/reconnect", QoS::Level2)];
     request.subscribe(topics).expect("Subcription failure");
 
     request.disconnect().unwrap();
@@ -130,7 +130,7 @@ fn acked_message() {
                                     .set_client_id("test-reconnect-client")
                                     .broker(BROKER_ADDRESS);
 
-    // Connects to a broker and returns a `request` 
+    // Connects to a broker and returns a `request`
     let mq_client = MqttClient::new(client_options);
     let mq_client = mq_client.publish_callback(|m| {
         let ref payload = *m.payload;
@@ -141,8 +141,8 @@ fn acked_message() {
         assert_eq!("MYUNIQUEUSERDATA".to_string(), userdata);
     });
     let request = mq_client.start().expect("Coudn't start");
-    request.userdata_publish("test/qos1/ack",  
-                             QoS::Level1, 
+    request.userdata_publish("test/qos1/ack",
+                             QoS::Level1,
                              "MYUNIQUEMESSAGE".to_string().into_bytes(),
                              "MYUNIQUEUSERDATA".to_string().into_bytes()).unwrap();
     thread::sleep(Duration::new(1, 0));
@@ -155,7 +155,7 @@ fn will() {
                                     .set_reconnect(15)
                                     .set_client_id("test-will-c1")
                                     .set_clean_session(false)
-                                    .set_will("test/will", "I'm dead")
+                                    .set_will("test/will", b"I'm dead")
                                     .broker(BROKER_ADDRESS);
 
     let client_options2 = MqttOptions::new()
@@ -219,7 +219,7 @@ fn retained_messages() {
     request.retained_publish("test/0/retain",  QoS::Level0, payload.clone().into_bytes()).unwrap();
     request.retained_publish("test/1/retain",  QoS::Level1, payload.clone().into_bytes()).unwrap();
     request.retained_publish("test/2/retain",  QoS::Level2, payload.clone().into_bytes()).unwrap();
-    
+
     // NOTE: Request notifications are on different mio channels. We don't know
     // about priority. Wait till all the publishes are recived by connection thread
     // before disconnection
@@ -305,7 +305,7 @@ fn simple_qos1_stress_publish() {
 /// This test tests if all packets are being published after reconnections
 /// NOTE: Previous tests used subscribes to same topic to decide if all the
 /// publishes are successful. When reconnections are involved, some publishes
-/// might happen before subscription is successful. You can verify this by 
+/// might happen before subscription is successful. You can verify this by
 /// keeping prints at CONNACK, SUBACK & _PUBLISH(). After connection is successful
 /// you'll see some publishes before SUBACK.
 fn qos1_stress_publish_with_reconnections() {
@@ -355,7 +355,7 @@ fn simple_qos2_stress_publish() {
         count.fetch_add(1, Ordering::SeqCst);
         // println!("{}. message --> {:?}", count.load(Ordering::SeqCst), message);
     }).start().expect("Coudn't start");
-    
+
     for i in 0..1000 {
         let payload = format!("{}. hello rust", i);
         request.publish("test/qos2/stress",  QoS::Level2, payload.clone().into_bytes()).unwrap();
@@ -383,7 +383,7 @@ fn qos2_stress_publish_with_reconnections() {
         count.fetch_add(1, Ordering::SeqCst);
         // println!("{}. message --> {:?}", count.load(Ordering::SeqCst), message);
     }).start().expect("Coudn't start");
-    
+
     for i in 0..1000 {
         let payload = format!("{}. hello rust", i);
         if i == 40 || i == 500 || i == 900 {
@@ -425,7 +425,7 @@ fn qos2_stress_publish_with_reconnections() {
 //         count.fetch_add(1, Ordering::SeqCst);
 //         // println!("{}. message --> {:?}", count.load(Ordering::SeqCst), message);
 //     }).start().expect("Coudn't start");
-    
+
 //     for i in 0..50 {
 //         let payload = format!("{}. hello rust", i);
 //         if i == 40 || i == 500 || i == 900 {


### PR DESCRIPTION
The underlying mqtt-protocol library recently updated to allow last wills to be arbritrary bytes, so we can now match that in our api.