### PR TITLE
Prevent Subscription with no topics

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -53,6 +53,11 @@ impl MqttClient {
     }
 
     pub fn subscribe(&mut self, topics: Vec<(&str, QualityOfService)>) -> Result<()> {
+        if topics.len() == 0 {
+            error!("It is invaild to send a subscribe message with zero topics");
+            return Err(Error::InvalidPacket);
+        }
+
         let mut sub_topics = Vec::with_capacity(topics.len());
         for topic in topics {
             let topic = (TopicFilter::new_checked(topic.0)?, topic.1);


### PR DESCRIPTION
If `client.subscribe()` is called with no topics (e.g. `client.subscribe(vec!())`), then the client will send a message that violates the MQTT specification. In our use case, it caused undesirable behavior in the broker.

[Here](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718063) is a link to the relevant MQTT specification.