### PR TITLE
Simplify passing generated IDs into `set_client_id`.

### DIFF
--- a/src/clientoptions.rs
+++ b/src/clientoptions.rs
@@ -73,10 +73,9 @@ impl MqttOptions {
     }
 
     /// Client id of the client. A random client id will be selected
-
     /// if you don't set one
-    pub fn set_client_id(mut self, client_id: &str) -> Self {
-        self.client_id = Some(client_id.to_string());
+    pub fn set_client_id<S: Into<String>>(mut self, client_id: S) -> Self {
+        self.client_id = Some(client_id.into());
         self
     }
 


### PR DESCRIPTION
The unique client ID passed to `set_client_id` will often be generated (otherwise it might be hard to keep it unique).
`set_client_id` was accepting a` &str` reference which makes passing a generating ID much harder and makes no sense performance-wise because `set_client_id` was converting it back to `String` anyways.
With this patch it is possible to pass a generated `String` to `set_client_id` directly. It's even faster, because the generated `String` can now be moved and not copied.