### PR TITLE
Make TLS support optional and add Rustls as an option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ threadpool = "1.3"
 quick-error = "1.1"
 mqtt-protocol = "0.3"
 openssl = { version = "0.9" }
+rustls = { version = "0.11.0" }
 
 [dev-dependencies]
 clippy = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ openssl = { version = "0.9", optional = true }
 rustls = { version = "0.11.0", optional = true }
 
 [features]
-default = ["tls-openssl"]
+default = []
 tls-openssl = ["openssl"]
 tls-rustls = ["rustls"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,13 @@ rand = "0.3"
 threadpool = "1.3"
 quick-error = "1.1"
 mqtt-protocol = "0.3"
-openssl = { version = "0.9" }
-rustls = { version = "0.11.0" }
+openssl = { version = "0.9", optional = true }
+rustls = { version = "0.11.0", optional = true }
+
+[features]
+default = ["tls-openssl"]
+tls-openssl = ["openssl"]
+tls-rustls = ["rustls"]
 
 [dev-dependencies]
 clippy = "0"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A pure rust mqtt client.
 
 * Supports QoS 0, QoS 1 and QoS 2
 * Auto reconnect
-* TLS support
+* Optional TLS support, either with OpenSSL via the `tls-openssl` feature, or Rustls with the `tls-rustls` feature
 * Offline message buffering
 * LWT
 * Authentication with username and password

--- a/src/clientoptions.rs
+++ b/src/clientoptions.rs
@@ -171,7 +171,7 @@ impl MqttOptions {
         self
     }
 
-    /// Set will retian so that future clients subscribing to will topic
+    /// Set will retain so that future clients subscribing to will topic
     /// knows of client's death.
     pub fn set_will_retain(mut self, retain: bool) -> Self {
         self.will_retain = retain;

--- a/src/clientoptions.rs
+++ b/src/clientoptions.rs
@@ -179,6 +179,8 @@ impl MqttOptions {
     }
 
     /// Set CA file for server authentication during TLS connection
+    /// Only available if compiled with openssl support, either tls-openssl or tls-rustls
+    #[cfg(any(feature = "tls-openssl", feature = "tls-rustls"))]
     pub fn set_ca<P>(mut self, cafile: P) -> Self
         where P: AsRef<Path>
     {
@@ -188,12 +190,16 @@ impl MqttOptions {
 
     /// Set flag to determine whether or not to verify server CA during TLS
     /// connection
+    /// Only available if compiled with tls-openssl. Rustls always requires verifying the CA
+    #[cfg(feature = "tls-openssl")]
     pub fn set_should_verify_ca(mut self, should_verify_ca: bool) -> Self {
         self.verify_ca = should_verify_ca;
         self
     }
 
     /// Set client cert and key for server to do client authentication
+    /// Only available if compiled with openssl support, either tls-openssl or tls-rustls
+    #[cfg(any(feature = "tls-openssl", feature = "tls-rustls"))]
     pub fn set_client_cert<P>(mut self, certfile: P, keyfile: P) -> Self
         where P: AsRef<Path>
     {

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,8 @@ use mqtt::packet::*;
 use mqtt::control::variable_header::ConnectReturnCode;
 use connection::NetworkRequest;
 
+use rustls::TLSError;
+
 pub type SslError = openssl::error::ErrorStack;
 pub type HandShakeError = openssl::ssl::HandshakeError<TcpStream>;
 pub type Result<T> = result::Result<T, Error>;
@@ -46,6 +48,9 @@ quick_error! {
         MqttPacket
         PingTimeout
         AwaitPingResp
+        Rustls(e: TLSError) {
+            from()
+        }
         Ssl(e: SslError) {
             from()
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,19 +1,15 @@
 use std::result;
 use std::io;
 use std::sync::mpsc::{TryRecvError, TrySendError, SendError};
-use std::net::TcpStream;
 
-use openssl;
 use mqtt::topic_name::TopicNameError;
 use mqtt::topic_filter::TopicFilterError;
 use mqtt::packet::*;
 use mqtt::control::variable_header::ConnectReturnCode;
 use connection::NetworkRequest;
 
-use rustls::TLSError;
+use stream::StreamError;
 
-pub type SslError = openssl::error::ErrorStack;
-pub type HandShakeError = openssl::ssl::HandshakeError<TcpStream>;
 pub type Result<T> = result::Result<T, Error>;
 
 quick_error! {
@@ -48,13 +44,7 @@ quick_error! {
         MqttPacket
         PingTimeout
         AwaitPingResp
-        Rustls(e: TLSError) {
-            from()
-        }
-        Ssl(e: SslError) {
-            from()
-        }
-        Handshake(e: HandShakeError) {
+        StreamError(e: StreamError) {
             from()
         }
         ConnectionRefused(e: ConnectReturnCode)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,8 +72,9 @@ extern crate threadpool;
 
 #[cfg(feature = "tls-openssl")] extern crate openssl;
 #[cfg(feature = "tls-rustls")] extern crate rustls;
+
 #[cfg(all(feature = "tls-rustls", feature = "tls-openssl"))]
-compile_error!("Multiple TLS implementations found. When compiling with tls feature support, only one of \"tls-rustls\" and \"tls-openssl\" may be used.");
+compile_error!("Multiple TLS implementations found. When compiling with TLS feature support, only one of \"tls-rustls\" and \"tls-openssl\" may be used.");
 
 mod error;
 mod genpack;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 #![cfg_attr(feature="clippy", feature(plugin))]
-
 #![cfg_attr(feature="clippy", plugin(clippy))]
-
 
 //! A fast, lock free Mqtt client implementation in Rust.
 //!
@@ -72,14 +70,10 @@ extern crate quick_error;
 extern crate mqtt;
 extern crate threadpool;
 
-/* cfg(openssl) */
-extern crate openssl;
-/* */
-
-/* cfg(rustls) */
-extern crate rustls;
-/* */
-
+#[cfg(feature = "tls-openssl")] extern crate openssl;
+#[cfg(feature = "tls-rustls")] extern crate rustls;
+#[cfg(all(feature = "tls-rustls", feature = "tls-openssl"))]
+compile_error!("Multiple TLS implementations found. When compiling with tls feature support, only one of \"tls-rustls\" and \"tls-openssl\" may be used.");
 
 mod error;
 mod genpack;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,8 +70,16 @@ extern crate log;
 #[macro_use]
 extern crate quick_error;
 extern crate mqtt;
-extern crate openssl;
 extern crate threadpool;
+
+/* cfg(openssl) */
+extern crate openssl;
+/* */
+
+/* cfg(rustls) */
+extern crate rustls;
+/* */
+
 
 mod error;
 mod genpack;

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1,0 +1,9 @@
+/* cfg(openssl)
+mod openssl;
+pub use self::openssl::{SslContext, NetworkStream};
+*/
+
+/* cfg(rustls) */
+mod rustls;
+pub use self::rustls::{SslContext, NetworkStream};
+/* */

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1,9 +1,17 @@
-/* cfg(openssl)
+#[cfg(feature = "tls-openssl")]
 mod openssl;
-pub use self::openssl::{SslContext, NetworkStream};
-*/
 
-/* cfg(rustls) */
+#[cfg(feature = "tls-openssl")]
+pub use self::openssl::{SslContext, NetworkStream, StreamError};
+
+#[cfg(feature = "tls-rustls")]
 mod rustls;
-pub use self::rustls::{SslContext, NetworkStream};
-/* */
+
+#[cfg(feature = "tls-rustls")]
+pub use self::rustls::{SslContext, NetworkStream, StreamError};
+
+#[cfg(not(any(feature = "tls-openssl", feature = "tls-rustls")))]
+mod no_tls;
+
+#[cfg(not(any(feature = "tls-openssl", feature = "tls-rustls")))]
+pub use self::no_tls::{NetworkStream, StreamError};

--- a/src/stream/no_tls.rs
+++ b/src/stream/no_tls.rs
@@ -1,0 +1,68 @@
+use std::net::TcpStream;
+use std::io::{self, Read, Write};
+use std::net::Shutdown;
+use std::time::Duration;
+
+#[derive(Debug)]
+pub struct StreamError;
+
+pub enum NetworkStream {
+    Tcp(TcpStream),
+    None,
+}
+
+impl NetworkStream {
+    // fn get_ref(&self) -> io::Result<&TcpStream> {
+    //     match *self {
+    //         NetworkStream::Tcp(ref s) => Ok(s),
+    // NetworkStream::None => Err(io::Error::new(io::ErrorKind::Other, "No
+    // stream!")),
+    //     }
+    // }
+
+    pub fn shutdown(&self, how: Shutdown) -> io::Result<()> {
+        match *self {
+            NetworkStream::Tcp(ref s) => s.shutdown(how),
+            NetworkStream::None => Err(io::Error::new(io::ErrorKind::Other, "No stream!")),
+        }
+    }
+
+    pub fn set_read_timeout(&mut self, dur: Option<Duration>) -> io::Result<()> {
+        match *self {
+            NetworkStream::Tcp(ref s) => s.set_read_timeout(dur),
+            NetworkStream::None => Err(io::Error::new(io::ErrorKind::Other, "No stream!")),
+        }
+    }
+
+    pub fn set_write_timeout(&mut self, dur: Option<Duration>) -> io::Result<()> {
+        match *self {
+            NetworkStream::Tcp(ref s) => s.set_write_timeout(dur),
+            NetworkStream::None => Err(io::Error::new(io::ErrorKind::Other, "No stream!")),
+        }
+    }
+}
+
+impl Read for NetworkStream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match *self {
+            NetworkStream::Tcp(ref mut s) => s.read(buf),
+            NetworkStream::None => Err(io::Error::new(io::ErrorKind::Other, "No stream!")),
+        }
+    }
+}
+
+impl Write for NetworkStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match *self {
+            NetworkStream::Tcp(ref mut s) => s.write(buf),
+            NetworkStream::None => Err(io::Error::new(io::ErrorKind::Other, "No stream!")),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match *self {
+            NetworkStream::Tcp(ref mut s) => s.flush(),
+            NetworkStream::None => Err(io::Error::new(io::ErrorKind::Other, "No stream!")),
+        }
+    }
+}

--- a/src/stream/openssl.rs
+++ b/src/stream/openssl.rs
@@ -8,10 +8,9 @@ use std::time::Duration;
 use openssl::ssl::{self, SslMethod, SSL_VERIFY_NONE, SSL_VERIFY_PEER};
 use openssl::x509::X509_FILETYPE_PEM;
 
-pub type SslStream = ssl::SslStream<TcpStream>;
-
 use error::Result;
 
+pub type SslStream = ssl::SslStream<TcpStream>;
 pub struct SslContext {
     pub inner: Arc<ssl::SslConnector>,
 }

--- a/src/stream/rustls.rs
+++ b/src/stream/rustls.rs
@@ -1,0 +1,140 @@
+use std::net::TcpStream;
+use std::fs::File;
+use std::io::{self, Read, Write, BufReader};
+use std::sync::Arc;
+use std::net::Shutdown;
+use std::path::Path;
+use std::time::Duration;
+
+use rustls::{PrivateKey, Certificate, Stream, ClientConfig, ClientSession, TLSError};
+use rustls::internal::pemfile;
+use error::Result;
+
+pub struct SslStream {
+  pub session: ClientSession,
+  pub stream: TcpStream
+}
+
+impl SslStream {
+  fn as_io<'a>(&'a mut self) -> Stream<'a, ClientSession, TcpStream> {
+    Stream::new(&mut self.session, &mut self.stream)
+  }
+}
+
+pub struct SslContext {
+    pub inner: Arc<ClientConfig>,
+}
+
+impl SslContext {
+    pub fn new<CA, C, K>(ca: CA, client_pair: Option<(C, K)>, _should_verify_ca: bool) -> Result<Self>
+        where CA: AsRef<Path>,
+              C: AsRef<Path>,
+              K: AsRef<Path>
+    {
+        let mut ctx_builder = ClientConfig::new();
+
+        let mut ca_file = try!(File::open(ca).map(|f| BufReader::new(f)));
+        try!(
+            ctx_builder.root_store
+                .add_pem_file(&mut ca_file)
+                .map_err(|_| TLSError::General("Unable to add CA file to root store".to_string()))
+        );
+        if let Some((cert, key)) = client_pair {
+            let cert_chain = try!(certs_from_pem_file(cert));
+            let key_der = try!(key_from_pem_file(key));
+            ctx_builder.set_single_client_cert(cert_chain, key_der);
+        }
+
+        Ok(SslContext { inner: Arc::new(ctx_builder) })
+    }
+
+    pub fn connect(&self, domain: &str, stream: TcpStream) -> Result<SslStream> {
+        let session = ClientSession::new(&self.inner, domain);
+        let ssl_stream = SslStream { session, stream };
+        Ok(ssl_stream)
+    }
+}
+
+fn certs_from_pem_file<C: AsRef<Path>>(path: C) -> Result<Vec<Certificate>> {
+    let mut cert_file = try!(File::open(path).map(|f| BufReader::new(f)));
+    pemfile::certs(&mut cert_file)
+      .map_err(|_| TLSError::General("Unable to read certs from pem file".to_string()).into())
+}
+
+fn key_from_pem_file<K: AsRef<Path>>(path: K) -> Result<PrivateKey> {
+    let mut key_file = try!(File::open(path).map(|f| BufReader::new(f)));
+    pemfile::rsa_private_keys(&mut key_file).and_then(|keys| {
+        keys.into_iter().next().ok_or(())
+    }).map_err(|_| {
+      TLSError::General("Unable to read private key from pem file".to_string()).into()
+    })
+}
+
+pub enum NetworkStream {
+    Tcp(TcpStream),
+    Tls(SslStream),
+    None,
+}
+
+impl NetworkStream {
+    // fn get_ref(&self) -> io::Result<&TcpStream> {
+    //     match *self {
+    //         NetworkStream::Tcp(ref s) => Ok(s),
+    //         NetworkStream::Tls(ref s) => Ok(s.get_ref()),
+    // NetworkStream::None => Err(io::Error::new(io::ErrorKind::Other, "No
+    // stream!")),
+    //     }
+    // }
+
+    pub fn shutdown(&self, how: Shutdown) -> io::Result<()> {
+        match *self {
+            NetworkStream::Tcp(ref s) => s.shutdown(how),
+            NetworkStream::Tls(ref s) => s.stream.shutdown(how),
+            NetworkStream::None => Err(io::Error::new(io::ErrorKind::Other, "No stream!")),
+        }
+    }
+
+    pub fn set_read_timeout(&mut self, dur: Option<Duration>) -> io::Result<()> {
+        match *self {
+            NetworkStream::Tcp(ref s) => s.set_read_timeout(dur),
+            NetworkStream::Tls(ref s) => s.stream.set_read_timeout(dur),
+            NetworkStream::None => Err(io::Error::new(io::ErrorKind::Other, "No stream!")),
+        }
+    }
+
+    pub fn set_write_timeout(&mut self, dur: Option<Duration>) -> io::Result<()> {
+        match *self {
+            NetworkStream::Tcp(ref s) => s.set_write_timeout(dur),
+            NetworkStream::Tls(ref s) => s.stream.set_write_timeout(dur),
+            NetworkStream::None => Err(io::Error::new(io::ErrorKind::Other, "No stream!")),
+        }
+    }
+}
+
+impl Read for NetworkStream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match *self {
+            NetworkStream::Tcp(ref mut s) => s.read(buf),
+            NetworkStream::Tls(ref mut s) => s.as_io().read(buf),
+            NetworkStream::None => Err(io::Error::new(io::ErrorKind::Other, "No stream!")),
+        }
+    }
+}
+
+impl Write for NetworkStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match *self {
+            NetworkStream::Tcp(ref mut s) => s.write(buf),
+            NetworkStream::Tls(ref mut s) => s.as_io().write(buf),
+            NetworkStream::None => Err(io::Error::new(io::ErrorKind::Other, "No stream!")),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match *self {
+            NetworkStream::Tcp(ref mut s) => s.flush(),
+            NetworkStream::Tls(ref mut s) => s.as_io().flush(),
+            NetworkStream::None => Err(io::Error::new(io::ErrorKind::Other, "No stream!")),
+        }
+    }
+}

--- a/src/stream/rustls.rs
+++ b/src/stream/rustls.rs
@@ -8,7 +8,22 @@ use std::time::Duration;
 
 use rustls::{PrivateKey, Certificate, Stream, ClientConfig, ClientSession, TLSError};
 use rustls::internal::pemfile;
-use error::Result;
+use error::{Result, Error};
+
+quick_error! {
+    #[derive(Debug)]
+    pub enum StreamError {
+        RustlsError(err: TLSError) {
+            from()
+        }
+    }
+}
+
+impl From<TLSError> for Error {
+  fn from(e: TLSError) -> Error {
+    Error::StreamError(e.into())
+  }
+}
 
 pub struct SslStream {
   pub session: ClientSession,


### PR DESCRIPTION
@tekjar Let me know if this PR is useful to you. This removes the hard dependency on OpenSSL, so those who aren't using TLS don't have to bring it in. It adds two choices for TLS via features: `tls-openssl`, which brings in openssl, and `tls-rustls`, which brings in [Rustls](https://github.com/ctz/rustls).

This is a breaking change, as existing users would now have to opt in to their TLS implementation, although users who aren't using the TLS-related helper methods (`.set_ca`, `.should_verify_ca`, `.set_client_cert`) wouldn't break. 

Another approach that would avoid limiting TLS choices to just openssl and Rustls would be to remove the deps entirely and have the end user bring in a companion crate (like adding a `rumqtt-openssl` or `rumqtt-rustls` or `rumqtt-some-other-tls` crate to their Cargo.toml) satisfying some trait we define for composing a NetworkStream.

Let me know what you think