### PR TITLE
[WIP] RFC - Add support for username and password auth over TLS

### DIFF
--- a/src/client/state.rs
+++ b/src/client/state.rs
@@ -143,7 +143,7 @@ impl MqttState {
 
         let (username, password) = match self.opts.security {
             SecurityOptions::UsernamePassword((ref username, ref password)) => (Some(username.to_owned()), Some(password.to_owned())),
-            SecurityOptions::GcloudIotCore((ref project, _, ref key, expiry)) => (Some("unused".to_owned()), Some(gen_iotcore_password(project, key, expiry)?)),
+            SecurityOptions::GcloudIotCore((ref project, ref key, expiry)) => (Some("unused".to_owned()), Some(gen_iotcore_password(project, key, expiry)?)),
             _ => (None, None),
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ mod client;
 mod error;
 
 // expose to other crates
-pub use mqttopts::{MqttOptions, ReconnectOptions, SecurityOptions};
+pub use mqttopts::{ConnectionMethod, MqttOptions, ReconnectOptions, SecurityOptions};
 pub use client::MqttClient;
 pub use mqtt3::QoS;
 pub use client::Notification;

--- a/src/mqttopts/mod.rs
+++ b/src/mqttopts/mod.rs
@@ -12,12 +12,16 @@ pub enum SecurityOptions {
     None,
     /// username, password
     UsernamePassword((String, String)),
-    /// ca, client cert, client key
-    Tls((String, String, String)),
-    /// project name, roots.pem, private_key.der to sign jwt, expiry in seconds
-    GcloudIotCore((String, String, String, i64))
+    /// project name, private_key.der to sign jwt, expiry in seconds
+    GcloudIotCore((String, String, i64))
 }
 
+#[derive(Clone, Debug)]
+pub enum ConnectionMethod {
+    Tcp,
+    // ca and, optionally, a pair of client cert and client key
+    Tls(String, Option<(String, String)>)
+}
 
 
 // TODO: Add getters & make fields private
@@ -32,6 +36,8 @@ pub struct MqttOptions {
     pub clean_session: bool,
     /// client identifier
     pub client_id: String,
+    /// connection method
+    pub connection_method: ConnectionMethod,
     /// reconnection options
     pub reconnect: ReconnectOptions,
     /// security options
@@ -53,6 +59,7 @@ impl MqttOptions {
             keep_alive: Some(10),
             clean_session: true,
             client_id: id.into(),
+            connection_method: ConnectionMethod::Tcp,
             reconnect: ReconnectOptions::AfterFirstSuccess(10),
             security: SecurityOptions::None,
             max_packet_size: 256 * 1024,
@@ -86,6 +93,12 @@ impl MqttOptions {
     /// So **make sure that you manually set `client_id` when `clean_session` is false**
     pub fn set_clean_session(mut self, clean_session: bool) -> Self {
         self.clean_session = clean_session;
+        self
+    }
+
+    /// Set how to connect to a MQTT Broker (either plain TCP or SSL)
+    pub fn set_connection_method(mut self, opts: ConnectionMethod) -> Self {
+        self.connection_method = opts;
         self
     }
 

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -19,16 +19,16 @@ mod tests {
         let (mut client, receiver) = MqttClient::start(mqtt_opts);
         let counter = Arc::new(Mutex::new(0));
 
-        client.subscribe(vec![("hello/world", QoS::AtLeastOnce)]);
+        client.subscribe(vec![("hello/world", QoS::AtLeastOnce)]).unwrap();
 
-        let counter_clone = counter.clone();
+        let counter_clone = Arc::clone(&counter);
         thread::spawn(move || {
-            for i in receiver {
+            for _ in receiver {
                 *counter_clone.lock().unwrap() += 1;
             }
         });
 
-        for i in 0..3 {
+        for _ in 0..3 {
             if let Err(e) = client.publish("hello/world", QoS::AtLeastOnce, vec![1, 2, 3]) {
                 println!("{:?}", e);
             }
@@ -45,7 +45,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn client_id_startswith_space() {
-        let mqtt_opts = MqttOptions::new(" client_a", "127.0.0.1:1883").unwrap()
+        let _mqtt_opts = MqttOptions::new(" client_a", "127.0.0.1:1883").unwrap()
                                     .set_reconnect_opts(ReconnectOptions::Always(10))
                                     .set_clean_session(true);
     }
@@ -53,7 +53,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn no_client_id() {
-        let mqtt_opts = MqttOptions::new("", "127.0.0.1:1883").unwrap()
+        let _mqtt_opts = MqttOptions::new("", "127.0.0.1:1883").unwrap()
                                     .set_reconnect_opts(ReconnectOptions::Always(10))
                                     .set_clean_session(true);
     }


### PR DESCRIPTION
For my use case (connecting to a cloudmqtt broker), I'd like to user the username / password auth over TLS. 

So now we have:

- `ConnectionMethod`: to pick a transport (either plain `Tcp `or `Tls`)
- `SecurityOptions`: to pick an authentication method (`None`, `UsernamePassword`, `GcloudIotCore`)

Let me know what you think