### PR TITLE
Feature-gate JWT

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ tokio-io = "0.1"
 bytes = "0.4"
 mqtt3 = { git = "https://github.com/tekjar/mqtt3" }
 chrono = "0.4"
-jsonwebtoken = "4"
+jsonwebtoken = { version = "4", optional = true }
 serde = "1"
 serde_derive = "1"
 failure = "0.1"
@@ -27,3 +27,7 @@ tokio-openssl = "0.2"
 [dev-dependencies]
 pretty_env_logger = "0.1"
 loggerv = "0.6"
+
+[features]
+default = ["jwt"]
+jwt = ["jsonwebtoken"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@ use futures::sync::mpsc::SendError;
 use mqtt3::Packet;
 use std::io::Error as IoError;
 use openssl;
+#[cfg(feature = "jwt")]
 use jwt;
 
 #[derive(Debug, Fail)]
@@ -46,6 +47,7 @@ pub enum ConnectError {
     Io(IoError),
     #[fail(display = "Tls failed. Error = {}", _0)]
     Tls(openssl::error::ErrorStack),
+    #[cfg(feature = "jwt")]
     #[fail(display = "Jwt creation failed")]
     Jwt,
     #[fail(display = "Empty dns list")]
@@ -92,6 +94,7 @@ impl From<openssl::error::ErrorStack> for ConnectError {
     }
 }
 
+#[cfg(feature = "jwt")]
 impl From<jwt::errors::Error> for ConnectError {
     fn from(err: jwt::errors::Error) -> ConnectError {
         error!("Jwt failed. Error = {:?}", err);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ extern crate bytes;
 extern crate chrono;
 #[macro_use]
 extern crate failure;
+#[cfg(feature = "jwt")]
 extern crate jsonwebtoken as jwt;
 #[macro_use]
 extern crate serde_derive;

--- a/src/mqttopts/mod.rs
+++ b/src/mqttopts/mod.rs
@@ -12,6 +12,7 @@ pub enum SecurityOptions {
     None,
     /// username, password
     UsernamePassword((String, String)),
+    #[cfg(feature = "jwt")]
     /// project name, private_key.der to sign jwt, expiry in seconds
     GcloudIotCore((String, String, i64))
 }


### PR DESCRIPTION
This makes JWT support optional in order not to pull the jsonwebtoken dependency.  The "jwt" feature is on by default in order not to break backwards compatibility.

Long story short .. my projects depends on both rumqtt and rocket and they have a conflicting transitive dependency on ring