### PR TITLE
Reconnect: Encode pending publishes only if the queue is non-empty

### DIFF
--- a/src/client/state.rs
+++ b/src/client/state.rs
@@ -167,7 +167,11 @@ impl MqttState {
         if self.opts.clean_session {
             None
         } else {
-            Some(self.outgoing_pub.clone())
+            if self.outgoing_pub.is_empty() {
+                None
+            } else {
+                Some(self.outgoing_pub.clone())
+            }
         }
     }
 
@@ -659,6 +663,30 @@ mod test {
         assert_eq!(None, mqtt.handle_reconnection());
     }
 
+    #[test]
+    fn connack_handle_should_not_return_list_of_incomplete_messages_to_be_sent_in_persistent_session_if_there_are_no_pending_messages() {
+        let mqtt_opts = MqttOptions::new("test-id", "127.0.0.1:1883").unwrap();
+        let mut mqtt = MqttState::new(mqtt_opts);
+        mqtt.opts.clean_session = false;
+
+        let publish = Publish {
+            dup: false,
+            qos: QoS::AtLeastOnce,
+            retain: false,
+            pid: None,
+            topic_name: "hello/world".to_owned(),
+            payload: Arc::new(vec![1, 2, 3]),
+        };
+
+        let connack = Connack {
+            session_present: false,
+            code: ConnectReturnCode::Accepted
+        };
+
+        mqtt.handle_incoming_connack(connack).unwrap();
+        assert_eq!(None, mqtt.handle_reconnection());
+    }
+    
     #[test]
     fn connack_handle_should_return_list_of_incomplete_messages_to_be_sent_in_persistent_session() {
         let mqtt_opts = MqttOptions::new("test-id", "127.0.0.1:1883").unwrap();


### PR DESCRIPTION
This closes AtherEnergy/rumqtt#61