### PR TITLE
Make argument types in MqttOptions::new independent

### DIFF
--- a/src/mqttopts/mod.rs
+++ b/src/mqttopts/mod.rs
@@ -53,7 +53,7 @@ pub struct MqttOptions {
 }
 
 impl MqttOptions {
-    pub fn new<S: Into<String>>(id: S, addr: S) -> Result<MqttOptions, ClientError> {
+    pub fn new<S: Into<String>, T: Into<String>>(id: S, addr: T) -> Result<MqttOptions, ClientError> {
         // TODO: Validate client id. Shouldn't be empty or start with spaces
         // TODO: Validate if addr is proper address type
         let id = id.into();


### PR DESCRIPTION
The two argument types need to be independent. Otherwise the instance cannot be created with both a `String` and a `&'static str` instance.

An example that doesn't currently compile:

```rust
let client_id = "hello".to_string();
let client = MqttOptions::new(client_id, "eu.thethings.network:1883");
```