### PR TITLE
Derive `Debug` for `MqttOptions`

### DIFF
--- a/src/clientoptions.rs
+++ b/src/clientoptions.rs
@@ -2,7 +2,7 @@ use rand::{self, Rng};
 use std::path::{Path, PathBuf};
 use mqtt::QualityOfService;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct MqttOptions {
     pub addr: String, // TODO: Use a default localhost here instead of option
     pub keep_alive: Option<u16>,


### PR DESCRIPTION
Hello,

I would like to define a custom structure
```
#[derive(Clone, Debug)]
pub struct Options {
    pub mqtt: MqttOptions,
    pub database_url: String,
}
```

However, right now it is impossible because `Debug` is not implemented for `MqttOptions`.

I thought we could derive `Debug` for `MqttOptions`, it wouldn't hurt anyone and maybe even would be useful for debugging purposes.

What do you think?