### PR TITLE
Tokio2 improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ serde_derive = "1"
 failure = "0.1"
 log = "0.3"
 crossbeam-channel = "0.1"
-openssl = "0.10"
-tokio-openssl = "0.2"
+native-tls = "0.1.5"
+tokio-tls = "0.1.4"
 
 [dev-dependencies]
 pretty_env_logger = "0.1"

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -121,6 +121,10 @@ impl Connection {
                 error!("Reactor stopped. v = {:?}", v);
                 Ok(())
             }
+            Err((ConnectError::Halt, _next)) => {
+                mqtt_state.borrow_mut().handle_disconnect();
+                Err((ConnectError::Halt, self.connection_count))
+            }
             Err((e, _next)) => {
                 mqtt_state.borrow_mut().handle_disconnect();
                 error!("Reactor stopped. e = {:?}", e);

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -57,7 +57,10 @@ impl MqttClient {
             'reconnect: loop {
                 if let Err((e, connection_count)) = connection.start() {
                     match e {
-                        ConnectError::Halt => {error!("Halting connection thread"); break 'reconnect},
+                        ConnectError::Halt => {
+                            info!("Halting connection thread");
+                            break 'reconnect;
+                        }
                         _ => (),
                     }
 

--- a/src/client/network.rs
+++ b/src/client/network.rs
@@ -1,13 +1,13 @@
 use std::io::{self, Read, Write};
 
 use tokio_core::net::TcpStream;
-use tokio_openssl::SslStream;
 use tokio_io::{AsyncRead, AsyncWrite};
 use futures::Poll;
+use tokio_tls::TlsStream;
 
 pub enum NetworkStream {
     Tcp(TcpStream),
-    Tls(SslStream<TcpStream>)
+    Tls(TlsStream<TcpStream>),
 }
 
 impl Read for NetworkStream {

--- a/src/error.rs
+++ b/src/error.rs
@@ -73,8 +73,32 @@ pub enum PublishError {
 pub enum PubackError {
     // #[fail(display = "Client not in connected state")]
     // InvalidState,
-    #[fail(display = "Received unsolicited acknowledgment")]
-    Unsolicited
+    #[fail(display = "Received unsolicited publish acknowledgment")]
+    Unsolicited,
+}
+
+#[derive(Debug, Fail)]
+pub enum PubrecError {
+    // #[fail(display = "Client not in connected state")]
+    // InvalidState,
+    #[fail(display = "Received unsolicited publish received")]
+    Unsolicited,
+}
+
+#[derive(Debug, Fail)]
+pub enum PubrelError {
+    // #[fail(display = "Client not in connected state")]
+    // InvalidState,
+    #[fail(display = "Received unsolicited publish release")]
+    Unsolicited,
+}
+
+#[derive(Debug, Fail)]
+pub enum PubcompError {
+    // #[fail(display = "Client not in connected state")]
+    // InvalidState,
+    #[fail(display = "Received unsolicited publish complete")]
+    Unsolicited,
 }
 
 #[derive(Debug, Fail)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use futures::sync::mpsc::SendError;
+use native_tls;
 use std::io::Error as IoError;
-use openssl;
 use client::Command;
 
 #[cfg(feature = "jwt")]
@@ -47,7 +47,7 @@ pub enum ConnectError {
     #[fail(display = "Io failed. Error = {}", _0)]
     Io(IoError),
     #[fail(display = "Tls failed. Error = {}", _0)]
-    Tls(openssl::error::ErrorStack),
+    Tls(native_tls::Error),
     #[cfg(feature = "jwt")]
     #[fail(display = "Jwt creation failed")]
     Jwt,
@@ -95,8 +95,8 @@ impl From<IoError> for ConnectError {
     }
 }
 
-impl From<openssl::error::ErrorStack> for ConnectError {
-    fn from(err: openssl::error::ErrorStack) -> ConnectError {
+impl From<native_tls::Error> for ConnectError {
+    fn from(err: native_tls::Error) -> ConnectError {
         ConnectError::Tls(err)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,8 @@ extern crate serde_derive;
 #[macro_use]
 extern crate log;
 extern crate crossbeam_channel;
-extern crate openssl;
-extern crate tokio_openssl;
+extern crate native_tls;
+extern crate tokio_tls;
 
 mod codec;
 mod packet;


### PR DESCRIPTION
This branch is not really ready for merging and I am not sure if I have the time to fix it. I wanted to share it since it contains two relevant changes:

- I switched out openssl with native-tls. This makes it easier to use on windows  and should make it possible to use ca certs that are not in an actual file (which is a pita for me)
- I implemented QoS 2

(Possible) issues:
- I could not properly implement the tls options since native-tls works with pkcs12 certs. However it will ignore those options but still use the system cert db to check certs. There is a plan to change native-tls to use pem certs after which this should be easy to fix
- I did not test the QoS2 stuff beyond "My program using QoS2 seem to work properly"

Do with it what you want :-D