### PR TITLE
Add retain flag to publish method

### DIFF
--- a/examples/disconnection.rs
+++ b/examples/disconnection.rs
@@ -13,7 +13,7 @@ fn main() {
         for i in 1..11 {
             let payload = format!("publish {}", i);
             thread::sleep(Duration::from_millis(100));
-            mqtt_client.publish("hello/world", QoS::AtLeastOnce, payload).unwrap();
+            mqtt_client.publish("hello/world", QoS::AtLeastOnce, false, payload).unwrap();
         }
 
         mqtt_client.disconnect().unwrap();
@@ -21,7 +21,7 @@ fn main() {
         for i in 11..21 {
             let payload = format!("publish {}", i);
             thread::sleep(Duration::from_millis(100));
-            mqtt_client.publish("hello/world", QoS::AtLeastOnce, payload).unwrap();
+            mqtt_client.publish("hello/world", QoS::AtLeastOnce, false, payload).unwrap();
         }
     });
 

--- a/examples/gcloud.rs
+++ b/examples/gcloud.rs
@@ -41,7 +41,7 @@ fn main() {
         for i in 0..100 {
             let payload = format!("publish {}", i);
             thread::sleep(Duration::from_secs(1));
-            mqtt_client.publish(topic.clone(), QoS::AtLeastOnce, payload).unwrap();
+            mqtt_client.publish(topic.clone(), QoS::AtLeastOnce, false, payload).unwrap();
         }
     });
 

--- a/examples/httpconnect.rs
+++ b/examples/httpconnect.rs
@@ -36,7 +36,7 @@ fn main() {
         for i in 0..100 {
             let payload = format!("publish {}", i);
             thread::sleep(Duration::from_millis(100));
-            mqtt_client.publish("hello/world", QoS::AtLeastOnce, payload).unwrap();
+            mqtt_client.publish("hello/world", QoS::AtLeastOnce, false, payload).unwrap();
         }
     });
 

--- a/examples/playpause.rs
+++ b/examples/playpause.rs
@@ -18,7 +18,7 @@ fn main() {
         for i in 0..100 {
             let payload = format!("publish {}", i);
             thread::sleep(dur);
-            c1.publish("hello/world", QoS::AtLeastOnce, payload).unwrap();
+            c1.publish("hello/world", QoS::AtLeastOnce, false, payload).unwrap();
         }
     });
 

--- a/examples/pubsub1.rs
+++ b/examples/pubsub1.rs
@@ -15,7 +15,7 @@ fn main() {
         for i in 0..100 {
             let payload = format!("publish {}", i);
             thread::sleep(Duration::from_millis(100));
-            mqtt_client.publish("hello/world", QoS::AtLeastOnce, payload).unwrap();
+            mqtt_client.publish("hello/world", QoS::AtLeastOnce, false, payload).unwrap();
         }
     });
 

--- a/examples/pubsub2.rs
+++ b/examples/pubsub2.rs
@@ -12,7 +12,7 @@ fn main() {
         for i in 0..100 {
             let payload = format!("publish {}", i);
             thread::sleep(Duration::from_secs(1));
-            mqtt_client.publish("hello/world", QoS::AtMostOnce, payload).unwrap();
+            mqtt_client.publish("hello/world", QoS::AtMostOnce, false, payload).unwrap();
         }
     });
 

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -18,7 +18,7 @@ fn main() {
             let payload = format!("publish {}", i);
             thread::sleep(sleep_time);
 
-            mqtt_client.publish("hello/world", QoS::AtLeastOnce, payload).unwrap();
+            mqtt_client.publish("hello/world", QoS::AtLeastOnce, false, payload).unwrap();
         }
 
         thread::sleep(sleep_time * 10);

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -22,7 +22,7 @@ fn main() {
         for i in 0..100 {
             let payload = format!("publish {}", i);
             thread::sleep(Duration::from_secs(1));
-            mqtt_client.publish(topic.clone(), QoS::AtLeastOnce, payload).unwrap();
+            mqtt_client.publish(topic.clone(), QoS::AtLeastOnce, false, payload).unwrap();
         }
     });
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -77,10 +77,11 @@ impl MqttClient {
     //
     //    }
 
-    pub fn publish<S, V>(&mut self, topic: S, qos: QoS, payload: V) -> Result<(), ClientError>
+    pub fn publish<S, V, B>(&mut self, topic: S, qos: QoS, retained: B, payload: V) -> Result<(), ClientError>
     where
         S: Into<String>,
         V: Into<Vec<u8>>,
+        B: Into<bool>,
     {
         let payload = payload.into();
         if payload.len() > self.max_packet_size {
@@ -90,31 +91,7 @@ impl MqttClient {
         let publish = Publish {
             dup: false,
             qos,
-            retain: false,
-            topic_name: topic.into(),
-            pkid: None,
-            payload: Arc::new(payload),
-        };
-
-        let tx = &mut self.request_tx;
-        tx.send(Request::Publish(publish)).wait()?;
-        Ok(())
-    }
-    
-    pub fn retained_publish<S, V>(&mut self, topic: S, qos: QoS, payload: V) -> Result<(), ClientError>
-    where
-        S: Into<String>,
-        V: Into<Vec<u8>>,
-    {
-        let payload = payload.into();
-        if payload.len() > self.max_packet_size {
-            return Err(ClientError::PacketSizeLimitExceeded);
-        }
-
-        let publish = Publish {
-            dup: false,
-            qos,
-            retain: true,
+            retain: retained.into(),
             topic_name: topic.into(),
             pkid: None,
             payload: Arc::new(payload),


### PR DESCRIPTION
implement a boolean parameter for #120.

Perhaps discussion should be made as to whether or not it would make sense to expose the publish struct in some way. You would be able to dynamically create one dependant on what you are looking for.

for example:
```
///Defaults to non retained, QOS 1 and publish should return error on malformed message
let mut message = MqttMessage::new();
message.payload("This is a payload")
                .topic("hello/world")
                .retain();

mqtt_client.publish(message);
```

I'm not sure about creating a dynamic impl inside a struct... can you do something like `mqtt_client::message::new();`? That would make things even easier in that you could call `.publish()` after the `.retain()`