### PR TITLE
ALPN support

### DIFF
--- a/examples/gcloud.rs
+++ b/examples/gcloud.rs
@@ -34,7 +34,7 @@ fn main() -> Result<(), io::Error> {
 
     let mut ca = vec!();
     File::open(Path::new("../../certs/roots.pem")).and_then(|mut f| f.read_to_end(&mut ca))?;
-    let connection_method = ConnectionMethod::Tls(ca, None);
+    let connection_method = ConnectionMethod::Tls { ca, cert_and_key: None, alpn: vec![] };
 
     let mqtt_options = MqttOptions::new(client_id, "mqtt.googleapis.com", 8883)
         .set_keep_alive(10)

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -9,7 +9,7 @@ fn main() {
     let client_cert = include_bytes!("tlsfiles/bike1.cert.pem").to_vec();
     let client_key = include_bytes!("tlsfiles/bike1.key.pem").to_vec();
 
-    let connection_method = ConnectionMethod::Tls(ca, Some((client_cert, client_key)));
+    let connection_method = ConnectionMethod::Tls { ca, cert_and_key: Some((client_cert, client_key)), alpn: vec![] };
 
     let mqtt_options = MqttOptions::new(client_id, "localhost", 8883)
         .set_keep_alive(10)

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -288,8 +288,14 @@ impl Connection {
         let builder = NetworkStream::builder();
 
         let builder = match connection_method {
-            ConnectionMethod::Tls(ca, Some((cert, key))) => builder.add_certificate_authority(&ca).add_client_auth(&cert, &key),
-            ConnectionMethod::Tls(ca, None) => builder.add_certificate_authority(&ca),
+            ConnectionMethod::Tls { ca, cert_and_key, alpn } => {
+                let builder = builder.add_certificate_authority(&ca).add_alpn_protocols(&alpn);
+                if let Some((ref cert, ref key)) = cert_and_key {
+                    builder.add_client_auth(cert, key)
+                } else {
+                    builder
+                }
+            },
             ConnectionMethod::Tcp => builder,
         };
 

--- a/src/client/network.rs
+++ b/src/client/network.rs
@@ -43,6 +43,7 @@ use crate::client::network::{generate_httpproxy_auth, resolve};
                 certificate_authority: None,
                 client_cert: None,
                 client_private_key: None,
+                alpn_protocols: Vec::new(),
                 http_proxy: None,
             }
         }
@@ -61,6 +62,7 @@ use crate::client::network::{generate_httpproxy_auth, resolve};
         certificate_authority: Option<Vec<u8>>,
         client_cert: Option<Vec<u8>>,
         client_private_key: Option<Vec<u8>>,
+        alpn_protocols: Vec<Vec<u8>>,
         http_proxy: Option<HttpProxy>,
     }
 
@@ -73,6 +75,12 @@ use crate::client::network::{generate_httpproxy_auth, resolve};
         pub fn add_client_auth(mut self, cert: &[u8], private_key: &[u8]) -> NetworkStreamBuilder {
             self.client_cert = Some(cert.to_vec());
             self.client_private_key = Some(private_key.to_vec());
+            self
+        }
+
+        pub fn add_alpn_protocols(mut self, protocols: &[Vec<u8>]) -> NetworkStreamBuilder {
+            self.alpn_protocols.append(&mut protocols.to_vec());
+            debug!("{:?}", &self.alpn_protocols);
             self
         }
 
@@ -119,6 +127,8 @@ use crate::client::network::{generate_httpproxy_auth, resolve};
                 (None, None) => (),
                 _ => unimplemented!(),
             };
+
+            config.set_protocols(&self.alpn_protocols);
 
             Ok(TlsConnector::from(Arc::new(config)))
         }

--- a/src/mqttoptions.rs
+++ b/src/mqttoptions.rs
@@ -34,8 +34,15 @@ pub enum SecurityOptions {
 pub enum ConnectionMethod {
     /// Plain text connection
     Tcp,
-    /// Encrypted connection. (ca data, optional client cert and key data)
-    Tls(Vec<u8>, Option<(Vec<u8>, Vec<u8>)>),
+    /// Encrypted connection.
+    Tls {
+        /// ca data
+        ca: Vec<u8>,
+        /// optional client cert and key data
+        cert_and_key: Option<(Vec<u8>, Vec<u8>)>,
+        /// ALPN extension protocols
+        alpn: Vec<Vec<u8>>,
+    },
 }
 
 /// Mqtt through http proxy


### PR DESCRIPTION
Added ALPN TLS extension support.

- Extend `ConnectionMethod` with `alpn` field.

## notice

Protocol candidates are represented as `Vec<String>`, but latest `rustls` (1.15.0) uses `Vec<Vec<u8>>`.
