### PR TITLE
Graceful shutdown

### DIFF
--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -185,24 +185,10 @@ impl Connection {
                 Err(true)
             }
             Err(NetworkError::NetworkStreamClosed) => {
-                // If this is expected behaviour, the client has called `disconnect` or
-                // he's using GcloudIot SecurityOptions and his / her jwt has expired
-                let is_gcp = match self.mqttoptions.security_opts() {
-                    SecurityOptions::GcloudIot(_, _, _) => true,
-                    _ => false
-                };
-                let is_disconnecting = self.mqtt_state.clone().borrow().is_disconnecting();
-
-                // generate some useful log output
-                if !(is_gcp || is_disconnecting) {
-                    error!("Network stream closed");
-                } else if is_gcp && !is_disconnecting {
-                    info!("jwt expired. continuing reconnection loop.");
-                }
-                else {
+                let mqtt_state = self.mqtt_state.clone().borrow();
+                if mqtt_state.is_disconnecting() {
                     info!("Shutting down gracefully");
                 }
-                // let reconnection policy handle this
                 Err(false)
             }
             Err(e) => {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -49,7 +49,7 @@ pub enum Request {
 /// Commands sent by the client to mqtt event loop. Commands
 /// are of higher priority and will be `select`ed along with
 /// [request]s
-/// 
+///
 /// request: enum.Request.html
 #[derive(Debug)]
 pub enum Command {
@@ -74,10 +74,10 @@ pub struct MqttClient {
 }
 
 impl MqttClient {
-    /// Starts a new mqtt connection in a thread and returns [mqttclient] 
+    /// Starts a new mqtt connection in a thread and returns [mqttclient]
     /// instance to send requests/commands to the event loop and a crossbeam
     /// channel receiver to receive notifications sent by the event loop.
-    /// 
+    ///
     /// See `select.rs` example
     /// [mqttclient]: struct.MqttClient.html
     pub fn start(opts: MqttOptions) -> Result<(Self, crossbeam_channel::Receiver<Notification>), ConnectError> {
@@ -160,8 +160,8 @@ impl MqttClient {
     /// Commands the network eventloop to disconnect from the broker.
     /// ReconnectOptions are not in affect here. [Resume] the
     /// network for reconnection
-    /// 
-    /// [Resume]: struct.MqttClient.html#method.resume 
+    ///
+    /// [Resume]: struct.MqttClient.html#method.resume
     pub fn pause(&mut self) -> Result<(), ClientError> {
         let tx = &mut self.command_tx;
         tx.send(Command::Pause).wait()?;
@@ -173,6 +173,14 @@ impl MqttClient {
     pub fn resume(&mut self) -> Result<(), ClientError> {
         let tx = &mut self.command_tx;
         tx.send(Command::Resume).wait()?;
+        Ok(())
+    }
+
+    /// Commands the network eventloop to gracefully shutdown
+    /// the connection to the broker.
+    pub fn shutdown(&mut self) -> Result<(), ClientError> {
+        let tx = &mut self.request_tx;
+        tx.send(Request::Disconnect).wait()?;
         Ok(())
     }
 }

--- a/src/client/mqttstate.rs
+++ b/src/client/mqttstate.rs
@@ -164,6 +164,13 @@ impl MqttState {
         self.outgoing_pub.len()
     }
 
+    pub fn is_disconnecting(&self) -> bool {
+        match self.connection_status {
+            MqttConnectionStatus::Disconnecting => true,
+            _ => false
+        }
+    }
+
     pub fn handle_incoming_puback(&mut self, pkid: PacketIdentifier) -> Result<(Notification, Request), NetworkError> {
         match self.outgoing_pub.iter().position(|x| x.pkid == Some(pkid)) {
             Some(index) => {

--- a/src/client/mqttstate.rs
+++ b/src/client/mqttstate.rs
@@ -13,6 +13,7 @@ use mqtt311::{Connack, Connect, ConnectReturnCode, Packet, PacketIdentifier, Pub
 enum MqttConnectionStatus {
     Handshake,
     Connected,
+    Disconnecting,
     Disconnected,
 }
 
@@ -68,6 +69,7 @@ impl MqttState {
                 let subscription = self.handle_outgoing_subscribe(subs)?;
                 Request::Subscribe(subscription)
             }
+            Packet::Disconnect => self.handle_outgoing_disconnect()?,
             _ => unimplemented!(),
         };
 
@@ -116,6 +118,11 @@ impl MqttState {
 
             Ok(())
         }
+    }
+
+    pub fn handle_outgoing_disconnect(&mut self) -> Result<Request, NetworkError> {
+        self.connection_status = MqttConnectionStatus::Disconnecting;
+        Ok(Request::Disconnect)
     }
 
     pub fn handle_reconnection(&mut self) -> VecDeque<Request> {


### PR DESCRIPTION
This PR introduces a new client method named `shutdown`, which allows the client to gracefully close the connection to the broker. 

### Implementation details:
The `request_tx` sends a `Request::Disconnect`. As a result, the `handle_outgoing_disconnect` method of the `MqttState` sets the `MqttConnectionStatus` to a new enum value named `Disconnecting`. To verfiy the client is currently disconnecting, `MqttState` now exposes a `is_disconnecting` method returning a `bool`.

This allows the mqtt event loop to verfiy, whether the `NetworkError::NetworkStreamClosed` error is actually expected to happen or not and jump out of the reconnect loop. For convenience, I pulled the `should_reconnect_again` function into the `impl` of the `Connection`, alleviating the necessity of passing in both, the reconnect opts and now also the `is_diconnecting` flag (as we don't want to be reconnected when we gracefully shutdown - even if our reconnect options state otherwise)