### PR TITLE
Various warning, compile and clippy fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: rust
+
+rust:
+  - stable
+  - beta
+  - nightly
+
+matrix:
+  allow_failures:
+    - rust: nightly
+  fast_finish: true
+
+cache: cargo
+before_cache:
+  - chmod -R a+r $HOME/.cargo
+
+# branches:
+#   only:
+#     - master
+
+notifications:
+  email:
+    on_success: never
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,7 @@ edition = "2018"
 license = "Unlicense"
 
 [dependencies]
-tokio = "^0.1.9"
-tokio-timer = "0.2.7"
-tokio-io = "0.1"
-tokio-codec = "0.1"
+tokio = { version = "^0.1.15", features = [ "codec", "io", "rt-full", "tcp", "timer" ], default-features = false }
 bytes = "0.4"
 futures = "0.1"
 crossbeam-channel = "0.3"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/AtherEnergy/rumqtt.svg)](https://travis-ci.org/AtherEnergy/rumqtt)
+
 Pure rust [MQTT] client
 
 [MQTT]: http://mqtt.org/

--- a/examples/pubsub1.rs
+++ b/examples/pubsub1.rs
@@ -3,11 +3,12 @@ use std::{thread, time::Duration};
 
 fn main() {
     pretty_env_logger::init();
-    let broker = "prod-mqtt-broker.atherengineering.in";
+    //let broker = "prod-mqtt-broker.atherengineering.in";
+    let broker = "test.mosquitto.org";
     let port = 1883;
 
     let reconnection_options = ReconnectOptions::Always(10);
-    let mqtt_options = MqttOptions::new("test-pubsub2", "test.mosquitto.org", port)
+    let mqtt_options = MqttOptions::new("test-pubsub2", broker, port)
                                     .set_keep_alive(10)
                                     .set_reconnect_opts(reconnection_options)
                                     .set_clean_session(false);

--- a/examples/reconnection.rs
+++ b/examples/reconnection.rs
@@ -1,7 +1,7 @@
 extern crate pretty_env_logger;
 extern crate rumqtt;
-use rumqtt::{MqttClient, MqttOptions};
-use std::thread;
+//use rumqtt::{MqttClient, MqttOptions};
+//use std::thread;
 
 fn main() {
     // pretty_env_logger::init();

--- a/examples/shutdown.rs
+++ b/examples/shutdown.rs
@@ -16,7 +16,7 @@ fn main() {
             mqtt_client.publish("hello/world", QoS::AtLeastOnce, false, payload).unwrap();
         }
 
-        mqtt_client.disconnect().unwrap();
+        mqtt_client.shutdown().unwrap();
 
         for i in 11..21 {
             let payload = format!("publish {}", i);

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -185,7 +185,7 @@ impl Connection {
                 Err(true)
             }
             Err(NetworkError::NetworkStreamClosed) => {
-                let mqtt_state = self.mqtt_state.clone().borrow();
+                let mqtt_state = self.mqtt_state.borrow();
                 if mqtt_state.is_disconnecting() {
                     info!("Shutting down gracefully");
                 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -30,6 +30,7 @@ pub enum Notification {
 #[doc(hidden)]
 /// Requests by the client to mqtt event loop. Request are
 /// handle one by one#[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum Request {
     Publish(Publish),

--- a/src/client/network.rs
+++ b/src/client/network.rs
@@ -4,7 +4,7 @@ use crate::client::network::stream::NetworkStream;
 use futures::Poll;
 use serde_derive::{Deserialize, Serialize};
 use std::net::SocketAddr;
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 
 #[cfg(feature = "rustls")]
 pub mod stream {
@@ -24,7 +24,7 @@ use crate::client::network::{generate_httpproxy_auth, lookup_ipv4};
         sync::Arc,
     };
     use tokio::{io::AsyncRead, net::TcpStream};
-    use tokio_codec::{Decoder, Framed, LinesCodec};
+    use tokio::codec::{Decoder, Framed, LinesCodec};
     use tokio_rustls::{
         rustls::{internal::pemfile, ClientConfig, ClientSession},
         TlsConnector, TlsStream,

--- a/src/client/network.rs
+++ b/src/client/network.rs
@@ -23,7 +23,7 @@ use crate::client::network::{generate_httpproxy_auth, lookup_ipv4};
         },
         sync::Arc,
     };
-    use tokio::{io::AsyncRead, net::TcpStream};
+    use tokio::net::TcpStream;
     use tokio::codec::{Decoder, Framed, LinesCodec};
     use tokio_rustls::{
         rustls::{internal::pemfile, ClientConfig, ClientSession},
@@ -31,6 +31,7 @@ use crate::client::network::{generate_httpproxy_auth, lookup_ipv4};
     };
     use webpki::DNSNameRef;
 
+    #[allow(clippy::large_enum_variant)]
     pub enum NetworkStream {
         Tcp(TcpStream),
         Tls(TlsStream<TcpStream, ClientSession>),
@@ -122,6 +123,7 @@ use crate::client::network::{generate_httpproxy_auth, lookup_ipv4};
             Ok(TlsConnector::from(Arc::new(config)))
         }
 
+        #[allow(clippy::too_many_arguments)]
         pub fn http_connect(
             &self,
             id: &str,

--- a/src/client/network.rs
+++ b/src/client/network.rs
@@ -145,7 +145,7 @@ use crate::client::network::{generate_httpproxy_auth, lookup_ipv4};
 
             addr.and_then(|proxy_address| TcpStream::connect(&proxy_address))
                 .and_then(|tcp| {
-                    let framed = tcp.framed(codec);
+                    let framed = Decoder::framed(codec, tcp);
                     future::ok(framed)
                 })
                 .and_then(|f| f.send(connect))

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -3,7 +3,7 @@
 use bytes::BytesMut;
 use mqtt311::{self, MqttRead, MqttWrite, Packet};
 use std::io::{self, Cursor, ErrorKind};
-use tokio_codec::{Decoder, Encoder};
+use tokio::codec::{Decoder, Encoder};
 
 /// Mqtt codec
 #[derive(Debug)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,7 @@ use mqtt311::Packet;
 use std::io::Error as IoError;
 use tokio::timer::{self, timeout};
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Fail, From)]
 pub enum ClientError {
     #[fail(display = "No subscriptions")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,7 @@ use futures::sync::mpsc::SendError;
 use jsonwebtoken;
 use mqtt311::Packet;
 use std::io::Error as IoError;
-use tokio_timer::{self, timeout};
+use tokio::timer::{self, timeout};
 
 #[derive(Debug, Fail, From)]
 pub enum ClientError {
@@ -72,7 +72,7 @@ pub enum NetworkError {
     #[fail(display = "Received unsolicited acknowledgment")]
     Unsolicited,
     #[fail(display = "Tokio timer error = {}", _0)]
-    Timer(tokio_timer::Error),
+    Timer(timer::Error),
     #[fail(display = "Tokio timer error = {}", _0)]
     TimeOut(timeout::Error<IoError>),
     #[fail(display = "User requested for reconnect")]


### PR DESCRIPTION
This PR contains some cleanup regarding compilation and clippy. Some of the clippy lints are just suppressed (`large_enum_variant` and `too_many_arguments`) and I'm not sure how to deal with that.
Feel free to merge partially. ;-) 