### PR TITLE
Notifications on connection state changes and reconnection handling

### DIFF
--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -27,7 +27,7 @@ use tokio::timer::{timeout, Delay, Timeout};
 pub struct Connection {
     mqtt_state: Rc<RefCell<MqttState>>,
     notification_tx: Sender<Notification>,
-    connection_tx: Option<Sender<Result<(), ConnectError>>>,
+    connection_tx: Sender<Result<(), ConnectError>>,
     connection_count: u32,
     mqttoptions: MqttOptions,
     is_network_enabled: bool,
@@ -50,7 +50,7 @@ impl Connection {
             let mut connection = Connection {
                 mqtt_state,
                 notification_tx,
-                connection_tx: Some(connection_tx),
+                connection_tx,
                 connection_count: 0,
                 mqttoptions,
                 is_network_enabled: true,
@@ -244,8 +244,7 @@ impl Connection {
         self.connection_count += 1;
 
         if self.connection_count == 1 {
-            let connection_tx = self.connection_tx.take().unwrap();
-            connection_tx.send(Ok(())).unwrap();
+            self.connection_tx.send(Ok(())).unwrap();
         }
     }
 
@@ -258,8 +257,7 @@ impl Connection {
         };
 
         if self.connection_count == 1 {
-            let connection_tx = self.connection_tx.take().unwrap();
-            connection_tx.send(error).unwrap();
+            self.connection_tx.send(error).unwrap();
         }
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -18,6 +18,8 @@ pub mod prepend;
 /// Incoming notifications from the broker
 #[derive(Debug)]
 pub enum Notification {
+    Connected,
+    Disconnected,
     Publish(Publish),
     PubAck(PacketIdentifier),
     PubRec(PacketIdentifier),

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -15,10 +15,10 @@ pub mod network;
 pub mod prepend;
 
 /// Incoming notifications from the broker
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum Notification {
     Connected,
-    Disconnected,
+    Disconnected(Result<(), ConnectError>),
     Publish(Publish),
     PubAck(PacketIdentifier),
     PubRec(PacketIdentifier),

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,12 +54,18 @@ pub enum ConnectError {
         _0
     )]
     NotConnackPacket(Packet),
+    #[fail(display = "Tokio timer error = {}", _0)]
+    Timer(timer::Error),
+    #[fail(display = "Tokio timer error = {}", _0)]
+    TimeOut(timeout::Error<IoError>),
     #[fail(display = "Empty response")]
     NoResponse,
     #[fail(display = "Builder doesn't contain certificate authority")]
     NoCertificateAuthority,
     #[fail(display = "Dummy unused error")]
     Unused,
+    #[fail(display = "Network error. Error = {}", _0)]
+    NetworkError(NetworkError)
 }
 
 #[derive(Debug, Fail, From)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,6 +58,8 @@ pub enum ConnectError {
     NoResponse,
     #[fail(display = "Builder doesn't contain certificate authority")]
     NoCertificateAuthority,
+    #[fail(display = "Dummy unused error")]
+    Unused,
 }
 
 #[derive(Debug, Fail, From)]

--- a/src/mqttoptions.rs
+++ b/src/mqttoptions.rs
@@ -62,6 +62,8 @@ pub struct MqttOptions {
     client_id: String,
     /// connection method
     connection_method: ConnectionMethod,
+    /// connection attempt timeout in seconds
+    connect_timeout: Duration,
     /// proxy
     proxy: Proxy,
     /// reconnection options
@@ -93,6 +95,7 @@ impl Default for MqttOptions {
             connection_method: ConnectionMethod::Tcp,
             proxy: Proxy::None,
             reconnect: ReconnectOptions::AfterFirstSuccess(10),
+            connect_timeout: Duration::from_secs(30),
             security: SecurityOptions::None,
             max_packet_size: 256 * 1024,
             last_will: None,
@@ -116,19 +119,8 @@ impl MqttOptions {
         MqttOptions {
             broker_addr: host.into(),
             port,
-            keep_alive: Duration::from_secs(60),
-            clean_session: true,
             client_id: id,
-            connection_method: ConnectionMethod::Tcp,
-            proxy: Proxy::None,
-            reconnect: ReconnectOptions::AfterFirstSuccess(10),
-            security: SecurityOptions::None,
-            max_packet_size: 256 * 1024,
-            last_will: None,
-            request_channel_capacity: 10,
-            notification_channel_capacity: 10,
-            outgoing_ratelimit: None,
-            outgoing_queuelimit: (100, Duration::from_secs(3)),
+            ..Default::default()
         }
     }
 
@@ -209,6 +201,17 @@ impl MqttOptions {
     pub fn set_reconnect_opts(mut self, opts: ReconnectOptions) -> Self {
         self.reconnect = opts;
         self
+    }
+
+    /// Set timeout for a connection attempt
+    pub fn set_connect_timeout(mut self, timeout: Duration) -> Self {
+        self.connect_timeout = timeout;
+        self
+    }
+
+    /// Timeout for a connection attempt
+    pub fn connect_timeout(&self) -> Duration {
+        self.connect_timeout
     }
 
     /// Reconnection options


### PR DESCRIPTION
Hi,

I scratched the notifications of the connection state. Instead of a plain `crossbeam_channel::Receiver` the notifications thing returned is struct that wraps this and a `oneshot` channel for the sender to detect if the receiving side is dropped.

Next I refactored the reconnection handling (think the `AfterFirstSuccess` was broken anyway ;-)) for pushing `Errors` along with `Notification::Disconnected`.

This PR tries to fix #139 and #82.

During implementing this patch I touhght the one or other time that merging `ConnectError` and `ClientError` is worth to consider. For the user a single `Error` type might also be more convenient.

I'm open for a discussion on the detail and expect comments!

Thanks,

@flxo 