### PR TITLE
Feature: Connection status notifications and notifications drop handling

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,10 +1,9 @@
 //! Structs to interact with mqtt eventloop
 use crate::error::{ClientError, ConnectError};
 use crate::MqttOptions;
-use crossbeam_channel;
-use futures::{sync::mpsc, Future, Sink};
+use futures::{sync::mpsc, sync::oneshot, Future, Sink};
 use mqtt311::{PacketIdentifier, Publish, QoS, Subscribe, Unsubscribe, SubscribeTopic};
-use std::sync::Arc;
+use std::{sync::Arc, ops::Deref};
 
 #[doc(hidden)]
 pub mod connection;
@@ -18,6 +17,8 @@ pub mod prepend;
 /// Incoming notifications from the broker
 #[derive(Debug)]
 pub enum Notification {
+    Connected,
+    Disconnected(Result<(), ConnectError>),
     Publish(Publish),
     PubAck(PacketIdentifier),
     PubRec(PacketIdentifier),
@@ -58,20 +59,34 @@ pub enum Command {
     Resume,
 }
 
-#[doc(hidden)]
-/// Combines handles returned by the eventloop
-pub struct UserHandle {
-    request_tx: mpsc::Sender<Request>,
-    command_tx: mpsc::Sender<Command>,
-    notification_rx: crossbeam_channel::Receiver<Notification>,
-}
-
 /// Handle to send requests and commands to the network eventloop
 #[derive(Clone)]
 pub struct MqttClient {
     request_tx: mpsc::Sender<Request>,
     command_tx: mpsc::Sender<Command>,
     max_packet_size: usize,
+}
+
+/// Notification reception handle
+pub struct Notifications {
+    pub notification_rx: crossbeam_channel::Receiver<Notification>,
+    _notification_closed_rx: oneshot::Receiver<()>,
+}
+
+impl Iterator for Notifications {
+    type Item = Notification;
+
+    fn next(&mut self) -> Option<Notification> {
+        self.notification_rx.recv().ok()
+    }
+}
+
+impl Deref for Notifications {
+    type Target = crossbeam_channel::Receiver<Notification>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.notification_rx
+    }
 }
 
 impl MqttClient {
@@ -81,12 +96,13 @@ impl MqttClient {
     ///
     /// See `select.rs` example
     /// [mqttclient]: struct.MqttClient.html
-    pub fn start(opts: MqttOptions) -> Result<(Self, crossbeam_channel::Receiver<Notification>), ConnectError> {
+    pub fn start(opts: MqttOptions) -> Result<(Self, Notifications), ConnectError> {
         let max_packet_size = opts.max_packet_size();
-        let UserHandle {
+        let connection::UserHandle {
             request_tx,
             command_tx,
             notification_rx,
+            notification_closed_rx,
         } = connection::Connection::run(opts)?;
 
         let client = MqttClient {
@@ -95,7 +111,12 @@ impl MqttClient {
             max_packet_size,
         };
 
-        Ok((client, notification_rx))
+        let notifications = Notifications {
+            notification_rx,
+            _notification_closed_rx: notification_closed_rx,
+        };
+
+        Ok((client, notifications))
     }
 
     /// Requests the eventloop for mqtt publish

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,6 +58,8 @@ pub enum ConnectError {
     NoResponse,
     #[fail(display = "Builder doesn't contain certificate authority")]
     NoCertificateAuthority,
+    #[fail(display = "Network error. Error = {}", _0)]
+    NetworkError(NetworkError),
 }
 
 #[derive(Debug, Fail, From)]
@@ -84,8 +86,6 @@ pub enum NetworkError {
     UserDisconnect,
     #[fail(display = "Network stream closed")]
     NetworkStreamClosed,
-    #[fail(display = "Throttle error while rate limiting")]
-    Throttle,
     #[fail(display = "Dummy error for converting () to network error")]
     Blah,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ pub mod codec;
 pub mod error;
 pub mod mqttoptions;
 
-pub use crate::client::{MqttClient, Notification};
+pub use crate::client::{MqttClient, Notification, Notifications};
 pub use crate::mqttoptions::{ConnectionMethod, MqttOptions, Proxy, ReconnectOptions, SecurityOptions};
 pub use crate::error::{ConnectError, ClientError};
 pub use crossbeam_channel::Receiver;


### PR DESCRIPTION
This is a follow up on #142 without any change on the reconnection behaviour.

Check channel state before sending notifications and distibute connection state changes. The notification Receiver is wrapped into a struct that contains a oneshot Receiver that allows the client to check whether the notification struct is dropped or not. Upon disconnections the corresponding `Error` is sent.