### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,15 +30,15 @@ version = "0.2"
 optional = true
 
 [dependencies.tokio-rustls]
-version = "0.8"
+version = "0.9"
 optional = true
 
 [dependencies.webpki]
-version = "0.18"
+version = "0.19"
 optional = true
 
 [dependencies.jsonwebtoken]
-version = "5.0.1"
+version = "6.0"
 optional = true
 
 [dependencies.chrono]


### PR DESCRIPTION
After upgrading to the latest versions of Actix I was getting the following compilation error.

```
**error: failed to select a version for `rumqtt`.
    ... required by package `server_mqtt v0.1.0 (/home/sam/git/server_mqtt)`
versions that meet the requirements `*` are: 0.30.1, 0.30.0, 0.10.1, 0.10.0, 0.5.0, 0.3.0

the package `rumqtt` links to the native library `ring-asm`, but it conflicts with a previous package which links to `ring-asm` as well:
package `ring v0.14.6`
    ... which is depended on by `webpki v0.19.1`
    ... which is depended on by `rustls v0.15.2`
    ... which is depended on by `tokio-rustls v0.9.2`
    ... which is depended on by `actix-server-config v0.1.1`
    ... which is depended on by `actix-http v0.1.4`**
```

I created a fork and updated the crate versions which linked back to ring, and I am now able to compile successfully.