### PR TITLE
Solved #151 by keeping track of if first connection was successful

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,15 +30,15 @@ version = "0.2"
 optional = true
 
 [dependencies.tokio-rustls]
-version = "0.9"
+version = "0.8"
 optional = true
 
 [dependencies.webpki]
-version = "0.19"
+version = "0.18"
 optional = true
 
 [dependencies.jsonwebtoken]
-version = "6.0"
+version = "5.0.1"
 optional = true
 
 [dependencies.chrono]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rumqtt"
 description = "Mqtt client for your IOT needs"
-version = "0.30.1"
+version = "0.30.2"
 authors = ["raviteja <mail@raviteja.tech"]
 documentation = "https://docs.rs/rumqtt"
 repository = "https://github.com/AtherEnergy/rumqtt"

--- a/src/mqttoptions.rs
+++ b/src/mqttoptions.rs
@@ -260,7 +260,7 @@ impl MqttOptions {
     pub fn request_channel_capacity(&self) -> usize {
         self.request_channel_capacity
     }
-    
+
     /// Enables throttling and sets outoing message rate to the specified 'rate'
     pub fn set_outgoing_ratelimit(mut self, rate: u64) -> Self {
         if rate == 0 {
@@ -276,7 +276,7 @@ impl MqttOptions {
         self.outgoing_ratelimit
     }
 
-    /// Sleeps for the 'delay' about of time before sending the next message if the 
+    /// Sleeps for the 'delay' about of time before sending the next message if the
     /// specified 'queue_size's are hit
     pub fn set_outgoing_queuelimit(mut self, queue_size: usize, delay: Duration) -> Self {
         if queue_size == 0 {


### PR DESCRIPTION
Tested it by first connecting to "broker.hivemq.com", with different reconnectoptions, 
Then disconnecting the internet connection, and noticed it tried to reconnect with AfterFirstSuccess(0)

then testing it by connecting to "braker.hivemq.com" (misspelled) with different options, and got an error returned in all cases except when using reconnectoption Always