### PR TITLE
Specify multiple dependencies to solve ring-asm issues with other crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,15 +30,15 @@ version = "0.2"
 optional = true
 
 [dependencies.tokio-rustls]
-version = "0.9"
+version = ">=0.8, <=0.9"
 optional = true
 
 [dependencies.webpki]
-version = "0.19"
+version = ">=0.18, <=0.19"
 optional = true
 
 [dependencies.jsonwebtoken]
-version = "6.0"
+version = ">=5.0.1, <=6.0"
 optional = true
 
 [dependencies.chrono]


### PR DESCRIPTION
Since the software seems to compile fine with either of these dependencies, allowing Cargo to chose the one that does not collide with ring-asm. 

This fixes the regression in #148 