### PR TITLE
Don't depend on concrete log implementation in libraries.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ failure = "0.1"
 derive_more = "0.13"
 base64 = "0.10"
 uuid = {version = "0.7", features = ["serde", "v4"]}
-pretty_env_logger = "0.2"
 mqtt311 = "0.2"
 
 [dependencies.native-tls]
@@ -30,7 +29,6 @@ version = "0.2"
 optional = true
 
 [dependencies.tokio-rustls]
-
 version = ">=0.8, <=0.9"
 optional = true
 
@@ -58,7 +56,7 @@ optional = true
 envy = "0.3"
 serde = "1"
 serde_derive = "1"
-base64 = "0.10"
+pretty_env_logger = "0.3"
 
 [features]
 default = ["rustls", "jwt"]


### PR DESCRIPTION
`pretty_env_logger` is only used in the examples and not (of course) in
the core of this library. Also `base64` is used in the library and needs
not to be stated as `dev-depenency`.